### PR TITLE
merge: release/v0.1.5 -> develop

### DIFF
--- a/release-notes/v0.1.5.md
+++ b/release-notes/v0.1.5.md
@@ -1,0 +1,32 @@
+# v0.1.5
+
+## Summary
+- 交付 Liepin 自动投递就绪门禁与结构化运行日志，补齐从执行到发布前校验的最小闭环。
+- 定义 autonomous delivery loop 的核心规范、OpenSpec 变更与实施计划，为下一阶段 agent 化交付提供统一基线。
+- 清理旧 GUI prototype 路径，统一到终版 GUI 设计审查清单。
+
+## Highlights
+- 新增 `tools/check_submission_readiness.py`，支持基于最新一次 `submit + success + screenshots` 的发布前门禁检查。
+- 增强 `tools/submission/liepin.py` 与 `tools/submission/run_submission.py`，支持 dry-run、check mode、submit mode、页面健康检查、DOM 快照和结构化日志。
+- 新增 `tools/submission/storage.py`，将投递运行结果持久化为 `submission_log.yaml` 与 `submission_log.json`。
+- 更新 `tools/run_github_publish.py` 与 `AIEF/context/tech/GITHUB_RELEASE.md`，支持将 submission readiness 作为可选发布门禁。
+- 新增 `openspec/changes/autonomous-agent-delivery-loop/` 与多份 `docs/plans/*.md`，明确 autonomous agent delivery loop 的提案、设计、任务拆分和 GUI/实现检查清单。
+- 移除 `ui/prototype/index.html`、`ui/prototype/REVIEW.md` 与 `AIEF/context/tech/GUI_WORKBENCH.md`，避免旧原型继续干扰终版 GUI 主线。
+
+## Breaking Changes
+- 旧 GUI prototype 路径已移除；GUI 审查应改为使用 `ui/design/` 真源与 `docs/plans/gui-review-checklist.md`。
+
+## Migration Guide
+- 自动投递检查模式：
+- `python3 -m tools.submission.run_submission --platform liepin --job-url <url> --resume <pdf> --profile profiles/candidate_profile.yaml --session-dir .sessions --output-dir outputs/submissions --timeout-ms 45000`
+- 自动投递提交模式：
+- `python3 -m tools.submission.run_submission --platform liepin --job-url <url> --resume <pdf> --profile profiles/candidate_profile.yaml --session-dir .sessions --output-dir outputs/submissions --submit`
+- 发布前门禁（可选但推荐）：
+- `python3 tools/check_submission_readiness.py --root outputs/submissions --platform liepin --require-status success --min-screenshots 1`
+- GUI 相关评审改为执行：
+- `docs/plans/gui-review-checklist.md`
+
+## Verification
+- `python3 tools/check_aief_l3.py --root . --base-dir AIEF`
+- `python3 -m tools.submission.run_submission --help`
+- `python3 tools/check_submission_readiness.py --help`


### PR DESCRIPTION
## Summary
- back-merge `release/v0.1.5` into `develop`
- carry `release-notes/v0.1.5.md` back to the development line after the main release