### PR TITLE
merge: release/v0.1.6 -> develop

### DIFF
--- a/release-notes/v0.1.6.md
+++ b/release-notes/v0.1.6.md
@@ -1,0 +1,32 @@
+# v0.1.6
+
+## Summary
+- 交付首个真实 desktop vertical slice：Tauri 宿主、React/TypeScript GUI 壳层与 Python sidecar RPC 闭环已经打通。
+- 让 `Overview`、`Evidence`、`System Settings` 三个页面从占位态进入 live data 模式，并补齐 macOS 打包 Python runtime 与 packaged-app smoke 验证。
+- 收敛 CI 门禁与打包文档约定，明确 AIEF L3 校验、desktop smoke workflow、release notes 触发边界与资源副本 source-of-truth。
+
+## Highlights
+- 新增 `tools/domain/`、`tools/infra/`、`tools/sidecar/` 与对应测试，形成面向 GUI bridge 的 domain / infra / sidecar 分层。
+- 新增 `ui/src/` React 前端、`ui/src-tauri/` 宿主与 `ui/scripts/stage_python_runtime.py`，将桌面应用运行路径统一到 `Tauri + React + Python sidecar`。
+- 新增 `ui/scripts/verify_packaged_app.py` 与 `npm run smoke:app`，验证打包后的 `.app` 能启动 bundled sidecar，并完成 `system.handshake` / `system.ping`。
+- 新增 `.github/workflows/ui-packaged-smoke.yml`，并收窄现有 workflows 的 `paths` 范围，避免无关改动消耗重型 CI。
+- 更新 `tools/README.md`、`AIEF/context/tech/GITHUB_RELEASE.md`、经验库 lessons/summaries，明确 CI 规则与 `ui/src-tauri/resources/tools/README.md` 的打包副本约定。
+
+## Breaking Changes
+- GUI 主线已明确收敛到 desktop app 路径；后续 GUI 相关实现、评审与打包验证应以 `ui/src/`、`ui/src-tauri/` 与 `ui/design/` 为准，而不是旧 prototype 路径。
+
+## Migration Guide
+- 前端开发与构建：
+- `cd ui && npm ci && npm run build`
+- desktop packaged smoke：
+- `cd ui && npm run smoke:app`
+- AIEF L3 校验：
+- `python3 tools/check_aief_l3.py --root . --base-dir AIEF`
+- 如果需要重新同步打包资源副本：
+- `python3 ui/scripts/stage_python_runtime.py`
+
+## Verification
+- `python3 -m pytest tests/unit tests/domain`
+- `cargo test` in `ui/src-tauri`
+- `npm run smoke:app`
+- `python3 tools/check_aief_l3.py --root . --base-dir AIEF`


### PR DESCRIPTION
## Summary
- backmerge `release/v0.1.6` into `develop` after the `main` release is complete
- keep `release-notes/v0.1.6.md` on `develop` so release-only documentation is not lost

## Validation
- release branch was merged to `main`
- tag `v0.1.6` was pushed
- GitHub Release `v0.1.6` was created