### PR TITLE
fix: submission retry persistence and UI race conditions

### DIFF
--- a/tests/unit/sidecar/test_submission_handler.py
+++ b/tests/unit/sidecar/test_submission_handler.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -300,9 +301,18 @@ class SubmissionRetryTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             submissions_dir = Path(tmp_dir) / "submissions"
             run_dir = submissions_dir / "liepin" / "20260304-124634"
+            original_ended_at = "2026-03-04T12:46:37+00:00"
             run_dir.mkdir(parents=True)
             (run_dir / "submission_log.json").write_text(
-                json.dumps({"run_id": "20260304-124634", "platform": "liepin"}),
+                json.dumps(
+                    {
+                        "run_id": "20260304-124634",
+                        "platform": "liepin",
+                        "status": "failed",
+                        "retry_count": 1,
+                        "ended_at": original_ended_at,
+                    }
+                ),
                 encoding="utf-8",
             )
             with patch(
@@ -316,9 +326,18 @@ class SubmissionRetryTests(unittest.TestCase):
                     }
                 )
 
+            updated_log = json.loads(
+                (run_dir / "submission_log.json").read_text(encoding="utf-8")
+            )
+
         self.assertEqual(result["meta"]["correlation_id"], "corr_003")
         self.assertEqual(result["submission_id"], "20260304-124634")
         self.assertEqual(result["status"], "queued")
+        self.assertEqual(updated_log["status"], "queued")
+        self.assertEqual(updated_log["retry_count"], 2)
+        self.assertNotEqual(updated_log["ended_at"], original_ended_at)
+        parsed_ended_at = datetime.fromisoformat(updated_log["ended_at"])
+        self.assertIsNotNone(parsed_ended_at.tzinfo)
 
     def test_retry_not_found_raises(self) -> None:
         with TemporaryDirectory() as tmp_dir:

--- a/tools/sidecar/handlers/submission.py
+++ b/tools/sidecar/handlers/submission.py
@@ -157,9 +157,19 @@ def handle_submission_retry(params: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"unsupported retry strategy: {strategy}")
 
     found = False
+    retried_at = datetime.now(timezone.utc).isoformat()
     for path in _submission_log_paths():
         payload = _load_submission_log(path)
         if str(payload.get("run_id", path.parent.name)) == submission_id:
+            payload["status"] = "queued"
+            payload["retry_count"] = _parse_cursor(payload.get("retry_count")) + 1
+            payload["retry_strategy"] = strategy
+            payload["ended_at"] = retried_at
+            payload["retried_at"] = retried_at
+            _ = path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
             found = True
             break
     if not found:

--- a/ui/src/pages/evidence/index.tsx
+++ b/ui/src/pages/evidence/index.tsx
@@ -70,17 +70,24 @@ export function EvidencePage() {
   }, [selectedId]);
 
   const loadDetail = useCallback(async (evidenceId: string) => {
+    selectedIdRef.current = evidenceId;
     setSelectedId(evidenceId);
     setDetailState("loading");
     setDetailError(null);
 
     try {
       const result = await getEvidence(evidenceId);
+      if (selectedIdRef.current !== evidenceId) {
+        return;
+      }
       setDetail(result.evidence);
       setForm(toForm(result.evidence));
       setIsDraft(false);
       setDetailState("ready");
     } catch (error) {
+      if (selectedIdRef.current !== evidenceId) {
+        return;
+      }
       setDetail(null);
       setForm(toForm(null));
       setDetailState("error");
@@ -163,7 +170,7 @@ export function EvidencePage() {
       setSaveState("idle");
       setDetailError(getErrorMessage(error));
     }
-  }, [form, isDraft, loadDetail, loadEvidence, selectedId]);
+  }, [form, isDraft, loadEvidence, selectedId]);
 
   const handleDelete = useCallback(async () => {
     if (!selectedId || isDraft) return;

--- a/ui/src/pages/resumes/index.tsx
+++ b/ui/src/pages/resumes/index.tsx
@@ -66,13 +66,19 @@ export function ResumesPage() {
   }, [selectedId]);
 
   const loadPreview = useCallback(async (resumeId: string) => {
+    selectedIdRef.current = resumeId;
+    setSelectedId(resumeId);
     try {
       const result = await getResumePreview(resumeId);
-      setSelectedId(resumeId);
+      if (selectedIdRef.current !== resumeId) {
+        return;
+      }
       setPreview(result.preview);
       setPreviewStatus(result.preview_status ?? null);
     } catch (nextError) {
-      setSelectedId(resumeId);
+      if (selectedIdRef.current !== resumeId) {
+        return;
+      }
       setPreview(null);
       setPreviewStatus(null);
       setError(getErrorMessage(nextError));


### PR DESCRIPTION
## Summary
Fixes two issues identified in code review:

1. **Submission retry was not persisting state** - The retry operation returned success but didn't actually update the submission log file, so refreshing the list would show the old status.

2. **Race conditions in evidence/resume pages** - Rapidly switching between items could cause old async responses to overwrite newer selections.

## Changes

### Backend
-  now writes to :
  - Sets  to "queued"
  - Increments 
  - Records   
  - Updates  and  timestamps
- Test updated to verify file is actually modified

### Frontend  
- Evidence page: Added  check in  - ignores response if user switched to different item
- Resumes page: Added  check in  - same protection for preview loading

## Verification
- ✅ pytest tests/unit/sidecar -q (112 passed)
- ✅ npm run build (TypeScript clean)
- ✅ Manual testing of rapid switching shows correct behavior