### PR TITLE
feat(agent): implement real REVIEW backend for Agent Run

### DIFF
--- a/AIEF/docs/plans/project-status-and-next-steps.md
+++ b/AIEF/docs/plans/project-status-and-next-steps.md
@@ -66,7 +66,7 @@
 | **run_agent.py** | core spec、design.md、tasks C6 | 仓库中不存在；无统一 Agent 循环入口。 |
 | **REVIEW 阶段与 RPC** | design.md、DESIGN.md | 无 getPendingReview/submitReview；无 REVIEW 状态分支。 |
 | **delivery_mode / batch_review** | design.md、DESIGN.md、tasks A10 | ✅ 已实现：sidecar settings 支持读写，Policy 页有完整控件。 |
-| **Agent Run 审批 UI** | DESIGN.md | ✅ 页面已实现：有审批列表、approve/reject/skip 按钮；后端为 stub（见 Issue #15）。 |
+| **Agent Run 审批 UI** | DESIGN.md | ✅ 已实现：前端页面 + 后端 handlers（run.agent.getPendingReview, submitReview, createReviewCandidates） |
 | **orchestration/** | tasks Phase C | 无 agent_loop、Stage 组合、pipeline 与 agent 统一编排。 |
 | **config/Composer** | tasks A12、core spec | 无 config 目录；无统一组装点。 |
 | **EngineRegistry + 引擎层** | tasks Phase B | 无 engines/registry；run_* 仍直接调现有脚本逻辑，存在 if use_llm 等。 |

--- a/tests/unit/sidecar/test_agent_handler.py
+++ b/tests/unit/sidecar/test_agent_handler.py
@@ -1,33 +1,121 @@
-import unittest
+"""Tests for agent run / REVIEW handlers."""
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from tools.sidecar.handlers.agent import (
+    handle_create_review_candidates,
     handle_get_pending_review,
     handle_submit_review,
 )
 
 
-class GetPendingReviewTests(unittest.TestCase):
-    def test_returns_candidates_key(self) -> None:
-        params = {"meta": {"correlation_id": "c1"}}
-        result = handle_get_pending_review(params)
-        self.assertIn("candidates", result)
-        self.assertEqual(result["candidates"], [])
+class TestCreateReviewCandidates:
+    def test_creates_candidates_successfully(self):
+        with TemporaryDirectory() as tmp:
+            review_dir = Path(tmp) / "review_queue"
+            with patch("tools.sidecar.handlers.agent._REVIEW_QUEUE_DIR", review_dir):
+                result = handle_create_review_candidates(
+                    {
+                        "meta": {"correlation_id": "corr_001"},
+                        "run_id": "run_2026_001",
+                        "candidates": [
+                            {
+                                "job_lead_id": "jl_001",
+                                "company": "Acme",
+                                "position": "Backend Engineer",
+                                "matching_score": 85,
+                                "evaluation_score": 90,
+                                "round_index": 1,
+                                "resume_version": "v1",
+                            }
+                        ],
+                    }
+                )
 
-    def test_stub_returns_empty_list(self) -> None:
-        params = {"meta": {"correlation_id": "c2"}}
-        result = handle_get_pending_review(params)
-        self.assertIsInstance(result["candidates"], list)
-        self.assertEqual(len(result["candidates"]), 0)
+        assert result["meta"]["correlation_id"] == "corr_001"
+        assert result["run_id"] == "run_2026_001"
+        assert result["created"] == 1
 
 
-class SubmitReviewTests(unittest.TestCase):
-    def test_returns_accepted_key(self) -> None:
-        params = {"meta": {"correlation_id": "c3"}, "decisions": []}
-        result = handle_submit_review(params)
-        self.assertIn("accepted", result)
-        self.assertEqual(result["accepted"], 0)
+class TestGetPendingReview:
+    def test_returns_pending_candidates(self):
+        with TemporaryDirectory() as tmp:
+            review_dir = Path(tmp) / "review_queue"
+            review_dir.mkdir()
+            queue_file = review_dir / "run_001.json"
+            queue_file.write_text(
+                json.dumps(
+                    {
+                        "run_id": "run_001",
+                        "candidates": [
+                            {
+                                "job_lead_id": "jl_001",
+                                "company": "Acme",
+                                "position": "Backend",
+                                "matching_score": 85,
+                                "evaluation_score": 90,
+                                "round_index": 1,
+                                "resume_version": "v1",
+                                "status": "pending",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
 
-    def test_stub_accepts_any_payload(self) -> None:
-        params = {"meta": {"correlation_id": "c4"}, "decisions": [{"job_lead_id": "jl-1", "action": "approve"}]}
-        result = handle_submit_review(params)
-        self.assertEqual(result["accepted"], 0)
+            with patch("tools.sidecar.handlers.agent._REVIEW_QUEUE_DIR", review_dir):
+                result = handle_get_pending_review(
+                    {"meta": {"correlation_id": "corr_002"}, "run_id": "run_001"}
+                )
+
+        assert len(result["candidates"]) == 1
+        assert result["candidates"][0]["job_lead_id"] == "jl_001"
+
+
+class TestSubmitReview:
+    def test_approves_candidates(self):
+        with TemporaryDirectory() as tmp:
+            review_dir = Path(tmp) / "review_queue"
+            review_dir.mkdir()
+            queue_file = review_dir / "run_001.json"
+            queue_file.write_text(
+                json.dumps(
+                    {
+                        "run_id": "run_001",
+                        "candidates": [
+                            {
+                                "job_lead_id": "jl_001",
+                                "company": "Acme",
+                                "position": "Backend",
+                                "matching_score": 85,
+                                "status": "pending",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("tools.sidecar.handlers.agent._REVIEW_QUEUE_DIR", review_dir):
+                result = handle_submit_review(
+                    {
+                        "meta": {"correlation_id": "corr_004"},
+                        "run_id": "run_001",
+                        "decisions": [
+                            {
+                                "job_lead_id": "jl_001",
+                                "action": "approve",
+                                "decided_by": "user",
+                            }
+                        ],
+                    }
+                )
+
+                updated = json.loads(queue_file.read_text(encoding="utf-8"))
+
+        assert result["accepted"] == 1
+        assert updated["candidates"][0]["status"] == "approved"

--- a/tools/sidecar/handlers/agent.py
+++ b/tools/sidecar/handlers/agent.py
@@ -1,23 +1,153 @@
-"""Agent run / REVIEW RPC handlers (stub until run_agent is wired)."""
+"""Agent run / REVIEW RPC handlers with real implementation."""
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+_REVIEW_QUEUE_DIR = Path("outputs") / "review_queue"
+
+
+def _utcnow_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _ensure_queue_dir() -> None:
+    _REVIEW_QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _get_queue_file(run_id: str | None = None) -> Path:
+    _ensure_queue_dir()
+    if run_id is None:
+        # Use the most recent queue file or create a default
+        files = sorted(_REVIEW_QUEUE_DIR.glob("*.json"))
+        if files:
+            return files[-1]
+        return _REVIEW_QUEUE_DIR / "default.json"
+    return _REVIEW_QUEUE_DIR / f"{run_id}.json"
+
+
+def _load_queue(queue_file: Path) -> dict[str, Any]:
+    if not queue_file.exists():
+        return {
+            "run_id": queue_file.stem,
+            "candidates": [],
+            "created_at": _utcnow_iso(),
+        }
+    return json.loads(queue_file.read_text(encoding="utf-8"))
+
+
+def _save_queue(queue_file: Path, queue: dict[str, Any]) -> None:
+    queue_file.write_text(
+        json.dumps(queue, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 def handle_get_pending_review(params: dict[str, Any]) -> dict[str, Any]:
-    """Return pending REVIEW candidates; stub: no active run → empty list."""
+    """Return pending REVIEW candidates for the active run."""
     correlation_id = params["meta"]["correlation_id"]
+    run_id = params.get("run_id")
+
+    queue_file = _get_queue_file(run_id)
+    queue = _load_queue(queue_file)
+
+    # Filter only pending candidates
+    pending = [c for c in queue.get("candidates", []) if c.get("status") == "pending"]
+
     return {
         "meta": {"correlation_id": correlation_id},
-        "candidates": [],
+        "candidates": pending,
     }
 
 
 def handle_submit_review(params: dict[str, Any]) -> dict[str, Any]:
-    """Accept review decisions; stub: no active run → accept count 0."""
+    """Accept review decisions and update candidate statuses."""
     correlation_id = params["meta"]["correlation_id"]
+    run_id = params.get("run_id")
+    decisions = params.get("decisions", [])
+
+    if not isinstance(decisions, list):
+        raise ValueError("decisions must be a list")
+
+    queue_file = _get_queue_file(run_id)
+    queue = _load_queue(queue_file)
+    candidates = queue.get("candidates", [])
+
+    accepted_count = 0
+
+    for decision in decisions:
+        job_lead_id = decision.get("job_lead_id")
+        action = decision.get("action")
+
+        # Find and update the candidate
+        for candidate in candidates:
+            if candidate.get("job_lead_id") == job_lead_id:
+                if action == "approve":
+                    candidate["status"] = "approved"
+                    accepted_count += 1
+                elif action == "reject":
+                    candidate["status"] = "rejected"
+                elif action in ("skip", "skip_all"):
+                    candidate["status"] = "skipped"
+
+                candidate["decided_by"] = decision.get("decided_by", "user")
+                candidate["decided_at"] = decision.get("decided_at", _utcnow_iso())
+                if "note" in decision:
+                    candidate["note"] = decision["note"]
+                break
+
+    _save_queue(queue_file, queue)
+
     return {
         "meta": {"correlation_id": correlation_id},
-        "accepted": 0,
+        "accepted": accepted_count,
+    }
+
+
+def handle_create_review_candidates(params: dict[str, Any]) -> dict[str, Any]:
+    """Internal API to create review candidates from a run (called by run_agent)."""
+    correlation_id = params["meta"]["correlation_id"]
+    run_id = params.get("run_id", "default")
+    candidates_data = params.get("candidates", [])
+
+    if not isinstance(candidates_data, list):
+        raise ValueError("candidates must be a list")
+
+    queue_file = _get_queue_file(run_id)
+
+    candidates = []
+    for data in candidates_data:
+        candidate = {
+            "job_lead_id": data.get("job_lead_id", ""),
+            "company": data.get("company", ""),
+            "position": data.get("position", ""),
+            "matching_score": data.get("matching_score", 0),
+            "evaluation_score": data.get("evaluation_score", 0),
+            "round_index": data.get("round_index", 0),
+            "resume_version": data.get("resume_version", ""),
+            "status": "pending",
+            "created_at": _utcnow_iso(),
+        }
+        if "job_url" in data:
+            candidate["job_url"] = data["job_url"]
+        candidates.append(candidate)
+
+    queue = {
+        "run_id": run_id,
+        "candidates": candidates,
+        "created_at": _utcnow_iso(),
+    }
+    _save_queue(queue_file, queue)
+
+    return {
+        "meta": {"correlation_id": correlation_id},
+        "run_id": run_id,
+        "created": len(candidates),
     }

--- a/tools/sidecar/server.py
+++ b/tools/sidecar/server.py
@@ -36,6 +36,7 @@ from tools.sidecar.handlers.submission import (
     handle_submission_retry,
 )
 from tools.sidecar.handlers.agent import (
+    handle_create_review_candidates,
     handle_get_pending_review,
     handle_submit_review,
 )
@@ -72,6 +73,7 @@ def _create_router() -> Router:
     router.register("settings.update", handle_settings_update)
     router.register("run.agent.getPendingReview", handle_get_pending_review)
     router.register("run.agent.submitReview", handle_submit_review)
+    router.register("run.agent.createReviewCandidates", handle_create_review_candidates)
     return router
 
 

--- a/ui/design/contracts/sidecar-rpc.md
+++ b/ui/design/contracts/sidecar-rpc.md
@@ -1138,3 +1138,98 @@
   - `ui/design/contracts/sidecar-rpc.md`
   - `ui/design/DESIGN.md` 中的协议摘要
   - 相关实现代码与测试
+
+### 6.15 run.agent.getPendingReview
+
+`params`
+
+```json
+{
+  "meta": { "correlation_id": "corr_001" },
+  "run_id": "run_2026_001"
+}
+```
+
+`result`
+
+```json
+{
+  "meta": { "correlation_id": "corr_001" },
+  "candidates": [
+    {
+      "job_lead_id": "jl_001",
+      "company": "Acme",
+      "position": "Backend Engineer",
+      "matching_score": 85,
+      "evaluation_score": 90,
+      "round_index": 1,
+      "resume_version": "v1",
+      "job_url": "https://example.com/job/1"
+    }
+  ]
+}
+```
+
+### 6.16 run.agent.submitReview
+
+`params`
+
+```json
+{
+  "meta": { "correlation_id": "corr_001" },
+  "run_id": "run_2026_001",
+  "decisions": [
+    {
+      "job_lead_id": "jl_001",
+      "action": "approve",
+      "decided_by": "user",
+      "decided_at": "2026-03-13T10:00:00Z",
+      "note": "Good match"
+    }
+  ]
+}
+```
+
+`result`
+
+```json
+{
+  "meta": { "correlation_id": "corr_001" },
+  "accepted": 1
+}
+```
+
+### 6.17 run.agent.createReviewCandidates
+
+Internal API for run_agent to populate review queue.
+
+`params`
+
+```json
+{
+  "meta": { "correlation_id": "corr_001" },
+  "run_id": "run_2026_001",
+  "candidates": [
+    {
+      "job_lead_id": "jl_001",
+      "company": "Acme",
+      "position": "Backend Engineer",
+      "matching_score": 85,
+      "evaluation_score": 90,
+      "round_index": 1,
+      "resume_version": "v1",
+      "job_url": "https://example.com/job/1"
+    }
+  ]
+}
+```
+
+`result`
+
+```json
+{
+  "meta": { "correlation_id": "corr_001" },
+  "run_id": "run_2026_001",
+  "created": 1
+}
+```


### PR DESCRIPTION
## Summary

Implement real REVIEW backend for Agent Run, replacing stub implementations.

Closes #15

## Changes

### Backend (tools/sidecar/handlers/agent.py)
- `handle_get_pending_review`: Returns actual pending candidates from review queue
- `handle_submit_review`: Persists approve/reject/skip decisions to JSON file
- `handle_create_review_candidates`: Internal API for run_agent to populate queue
- File storage: `outputs/review_queue/{run_id}.json`

### Registration (tools/sidecar/server.py)
- Added `run.agent.createReviewCandidates` handler registration

### Tests (tests/unit/sidecar/test_agent_handler.py)
- 3 test cases covering create, get pending, and submit review
- All tests pass

### Documentation (同步更新 ✅)
- **project-status-and-next-steps.md**: Marked Agent Run as fully implemented
- **sidecar-rpc.md**: Added API contracts for 3 new RPC methods

## Verification

- ✅ tests/unit/sidecar/test_agent_handler.py: 3 passed
- ✅ All sidecar tests: 112 passed
- ✅ UI build: successful (no changes needed, already implemented)

## API Usage

```python
# 1. Create review candidates (called by run_agent)
handle_create_review_candidates({
    "meta": {"correlation_id": "..."},
    "run_id": "run_001",
    "candidates": [...]
})

# 2. Get pending candidates (UI calls this)
handle_get_pending_review({
    "meta": {"correlation_id": "..."},
    "run_id": "run_001"
})

# 3. Submit review decisions (UI calls this)
handle_submit_review({
    "meta": {"correlation_id": "..."},
    "run_id": "run_001",
    "decisions": [{"job_lead_id": "...", "action": "approve"}]
})
```
